### PR TITLE
Fix for logic within regex, by removing the trailing slash we can avoid this issue.

### DIFF
--- a/src/Kjac.HeadlessPreview/Client/src/workspaces/actions/save-and-preview.workspace.action.ts
+++ b/src/Kjac.HeadlessPreview/Client/src/workspaces/actions/save-and-preview.workspace.action.ts
@@ -35,7 +35,7 @@ export class DocumentSaveAndPreviewWorkspaceAction extends UmbSubmitWorkspaceAct
         await super.execute();
         const workspaceContext = await this.getContext(UMB_DOCUMENT_WORKSPACE_CONTEXT);
         const unique = workspaceContext?.getUnique();
-        var currentLocation = window.location.href.replace(/\/+$/, '');
+        const currentLocation = window.location.href.replace(/\/+$/, '');
         const match = currentLocation.match(new RegExp(`.*\/${unique}\/(?<variant>[\\w-]*)(?<view>\\S*)`))
         if (!match || !match.length) {
             console.error('Could not match against current location, unable to switch to preview.')


### PR DESCRIPTION
A suggestion to fix the specific issue whenever the URL of current location contains an ending slash.

Trimming the current location on the ending slash, will result in the correct replacement 